### PR TITLE
fix: SSR next example

### DIFF
--- a/examples/next/.gitignore
+++ b/examples/next/.gitignore
@@ -12,6 +12,7 @@ node_modules
 /.next
 
 # misc
+/.vscode
 .DS_Store
 .env
 npm-debug.log*

--- a/examples/next/components/app.js
+++ b/examples/next/components/app.js
@@ -18,6 +18,7 @@ export default class extends React.Component {
         appId="latency"
         apiKey="6be0576ff61c053d5f9a3225e2a90f76"
         indexName="instant_search"
+        searchState={this.props.searchState}
         resultsState={this.props.resultsState}
       >
         <AppContext.Provider value={{ indexName }}>

--- a/examples/next/pages/index.js
+++ b/examples/next/pages/index.js
@@ -30,6 +30,7 @@ export default class extends React.Component {
         <Head title="Home" />
         <div>
           <AppProvider
+            searchState={this.props.searchState}
             resultsState={this.props.resultsState}
             onSearchStateChange={this.onSearchStateChange}>
               <AppSearch />

--- a/examples/next/pages/index.js
+++ b/examples/next/pages/index.js
@@ -18,7 +18,12 @@ export default class extends React.Component {
      to initialize the searchState.
   */
   static async getInitialProps() {
-    const searchState = { refinementList: ["Cell Phones"] }
+    const searchState = {
+      refinementList: {
+        categories: ['Cell Phones', 'Appliances']
+      },
+    };
+
     const resultsState = await findResultsState(AppProvider, { searchState });
     console.log(resultsState);
     return { resultsState, searchState };

--- a/examples/next/pages/index.js
+++ b/examples/next/pages/index.js
@@ -4,9 +4,7 @@ import Router from 'next/router';
 import qs from 'qs';
 import { Head, AppProvider, findResultsState, AppSearch } from '../components';
 
-
-
-export default class extends React.Component {
+class App extends React.Component {
   static propTypes = {
     resultsState: PropTypes.object,
   };
@@ -24,7 +22,7 @@ export default class extends React.Component {
       },
     };
 
-    const resultsState = await findResultsState(AppProvider, { searchState });
+    const resultsState = await findResultsState(App, { searchState });
     console.log(resultsState);
     return { resultsState, searchState };
   }
@@ -45,3 +43,5 @@ export default class extends React.Component {
     );
   }
 }
+
+export default App;


### PR DESCRIPTION
The issue was not with the Context API but a several misses around SSR:

The first issue was that the `searchState` was not correctly pass down to the InstantSearch provider (see https://github.com/andrewl913/react-instantsearch/commit/de5c59aaebc9f7aaa4d00cd06871e39ba810dcc0).

The second issue was that the shape of the `searchState` was not correct (see:  https://github.com/andrewl913/react-instantsearch/commit/6d5da244165fb14608530e11accb3f91ec86346b).

The last issue was that the component (`AppProvider`) provided to `findResultsState` didn't contained any React InstantSearch widgets. The widgets are provided as children to `AppProvider` inside the entry point. Now that we provide the full App to the function the widgets are mounted and the search is correctly applied (see https://github.com/andrewl913/react-instantsearch/commit/e1cdfb60a9b9aac7a4c5da82243dec753ad39a45)

Don't hesitate to ask any questions!